### PR TITLE
JENKINS-29576: Change the check for credentials to check null rather than not null

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/extensions/AWSEBElasticBeanstalkSetup.java
+++ b/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/extensions/AWSEBElasticBeanstalkSetup.java
@@ -153,7 +153,7 @@ public class AWSEBElasticBeanstalkSetup extends AWSEBSetup {
             }
         }
         
-        if (credentials != null) {
+        if (credentials == null) {
             throw new NullPointerException("No credentials provided for build!!!");
         }
         return credentials;


### PR DESCRIPTION
In reference to https://issues.jenkins-ci.org/browse/JENKINS-29576, it appears that the issue wasn't just with using the temporary credentials (IAM Role).