### PR TITLE
Allow for empty credentials, allowing box IAM roles or ENV variables

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBEnvironmentUpdater.java
+++ b/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBEnvironmentUpdater.java
@@ -47,7 +47,12 @@ public class AWSEBEnvironmentUpdater {
         failOnError = envSetup.getFailOnError();
         
 
-        AWSCredentialsProvider provider = envSetup.getActualcredentials(build, listener).getAwsCredentials();
+        AWSEBCredentials credentials = envSetup.getActualcredentials(build, listener);
+        AWSCredentialsProvider provider = null;
+        if (credentials != null) {
+            provider = envSetup.getActualcredentials(build, listener).getAwsCredentials();
+        }
+        
         Region region = Region.getRegion(envSetup.getAwsRegion(build, listener));
         
         awseb = AWSEBUtils.getElasticBeanstalk(provider, region);

--- a/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/extensions/AWSEBElasticBeanstalkSetup.java
+++ b/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/extensions/AWSEBElasticBeanstalkSetup.java
@@ -154,7 +154,7 @@ public class AWSEBElasticBeanstalkSetup extends AWSEBSetup {
         }
         
         if (credentials == null) {
-            throw new NullPointerException("No credentials provided for build!!!");
+            listener.getLogger().println("No credentials provided for build!!!");
         }
         return credentials;
     }


### PR DESCRIPTION
This will allow for credentials to be set in other manners.  No reason to restrict to just plugin credentials.