### PR TITLE
Update aws-java-sdk version to 1.10.49

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.10.5.1</version>
+            <version>1.10.49</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-codec</groupId>
@@ -100,7 +100,7 @@
         </dependency><dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-elasticbeanstalk</artifactId>
-            <version>1.10.5.1</version>
+            <version>1.10.49</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-codec</groupId>


### PR DESCRIPTION
At 06 Jan 2016, Amazon announced AWS Asia Pacific Seoul(ap-northeast-2) Region, but aws-java-sdk 1.10.5.1 does not support(only 1.10.49 or later support).