### PR TITLE
Set a different AWS region for the S3 uploader

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBBuilderBackwardsCompatibility.java
+++ b/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBBuilderBackwardsCompatibility.java
@@ -27,7 +27,7 @@ public abstract class AWSEBBuilderBackwardsCompatibility extends Builder impleme
             if (isNotBlank(applicationName) || (environments != null && environments.size() > 0) || isNotBlank(versionLabelFormat)) {
                 List<AWSEBSetup> s3Setup = new ArrayList<AWSEBSetup>(1);
                 if (isNotBlank(bucketName) || isNotBlank(keyPrefix)) {
-                    s3Setup.add(new AWSEBS3Setup(bucketName, keyPrefix, 
+                    s3Setup.add(new AWSEBS3Setup(bucketName, awsRegion.getName(), keyPrefix,
                             rootObject, includes, excludes, overwriteExistingFile));
                     bucketName = null;
                     keyPrefix = null;

--- a/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBPublisherBackwardsCompatibility.java
+++ b/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBPublisherBackwardsCompatibility.java
@@ -27,7 +27,7 @@ public abstract class AWSEBPublisherBackwardsCompatibility  extends Recorder {
             if (isNotBlank(applicationName) || (environments != null && environments.size() > 0) || isNotBlank(versionLabelFormat)) {
                 List<AWSEBSetup> s3Setup = new ArrayList<AWSEBSetup>(2);
                 if (isNotBlank(bucketName) || isNotBlank(keyPrefix)) {
-                    s3Setup.add(new AWSEBS3Setup(bucketName, keyPrefix, 
+                    s3Setup.add(new AWSEBS3Setup(bucketName, awsRegion.getName(), keyPrefix,
                             rootObject, includes, excludes, overwriteExistingFile));
                     bucketName = null;
                     keyPrefix = null;

--- a/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBS3Uploader.java
+++ b/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBS3Uploader.java
@@ -29,6 +29,7 @@ public class AWSEBS3Uploader {
     
     private final String keyPrefix;
     private final String bucketName;
+    private final String bucketRegion;
     private final String includes;
     private final String excludes;
     private final String rootObject;
@@ -57,6 +58,7 @@ public class AWSEBS3Uploader {
         this.versionLabel = AWSEBUtils.getValue(build, listener, versionLabel);
         this.keyPrefix = AWSEBUtils.getValue(build, listener, s3Setup.getKeyPrefix());
         this.bucketName = AWSEBUtils.getValue(build, listener, s3Setup.getBucketName());
+        this.bucketRegion = AWSEBUtils.getValue(build, listener, s3Setup.getBucketRegion());
         this.includes = AWSEBUtils.getValue(build, listener, s3Setup.getIncludes());
         this.excludes = AWSEBUtils.getValue(build, listener, s3Setup.getExcludes());
         this.rootObject = AWSEBUtils.getValue(build, listener, s3Setup.getRootObject());
@@ -71,7 +73,11 @@ public class AWSEBS3Uploader {
 
     public void uploadArchive(AWSElasticBeanstalk awseb) throws Exception {
         if (s3 == null) {
-            s3 = AWSEBUtils.getS3(credentials, awsRegion);
+            // Check whether we should use the env region or the bucket one.
+            if(this.bucketRegion.isEmpty())
+                s3 = AWSEBUtils.getS3(credentials, awsRegion);
+            else
+                s3 = AWSEBUtils.getS3(credentials, Regions.fromName(bucketRegion));
         }
 
         objectKey = AWSEBUtils.formatPath("%s/%s-%s.zip", keyPrefix, applicationName, versionLabel);

--- a/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/extensions/AWSEBS3Setup.java
+++ b/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/extensions/AWSEBS3Setup.java
@@ -13,8 +13,9 @@ public class AWSEBS3Setup extends AWSEBSetup {
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
     @DataBoundConstructor
-    public AWSEBS3Setup(String bucketName, String keyPrefix, String rootObject, String includes, String excludes, Boolean overwriteExistingFile) {
+    public AWSEBS3Setup(String bucketName, String bucketRegion, String keyPrefix, String rootObject, String includes, String excludes, Boolean overwriteExistingFile) {
         this.bucketName = bucketName;
+        this.bucketRegion = bucketRegion;
         this.keyPrefix = keyPrefix;
         this.rootObject = rootObject;
         this.overwriteExistingFile = overwriteExistingFile == null ? false : overwriteExistingFile;
@@ -29,6 +30,15 @@ public class AWSEBS3Setup extends AWSEBSetup {
 
     public String getBucketName() {
         return bucketName;
+    }
+
+    /**
+     * Bucket Region
+     */
+    private final String bucketRegion;
+
+    public String getBucketRegion() {
+        return bucketRegion;
     }
 
     /**

--- a/src/main/resources/org/jenkinsci/plugins/awsbeanstalkpublisher/extensions/AWSEBS3Setup/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsbeanstalkpublisher/extensions/AWSEBS3Setup/config.jelly
@@ -21,7 +21,14 @@
         <option value=""></option>
         <j:invokeStatic className="com.amazonaws.regions.Regions" method="values" var="regionsAvailable" />
         <j:forEach items="${regionsAvailable}"  var="rgs">
-            <option value="${rgs.getName()}">${rgs.getName()}</option>
+            <j:choose>
+                <j:when test="${instance.bucketRegion.equals(rgs.getName())}">
+                    <option value="${rgs.getName()}" selected="selected">${rgs.getName()}</option>
+                </j:when>
+                <j:otherwise>
+                    <option value="${rgs.getName()}">${rgs.getName()}</option>
+                </j:otherwise>
+            </j:choose>
         </j:forEach>
       </select>
   </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/awsbeanstalkpublisher/extensions/AWSEBS3Setup/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsbeanstalkpublisher/extensions/AWSEBS3Setup/config.jelly
@@ -15,7 +15,17 @@
   <f:entry title="Root Object (File / Directory)" field="rootObject">
     <f:textbox />
   </f:entry>
-  
+
+  <f:entry title="S3 Bucket Region" field="bucketRegion">
+      <select name="bucketRegion">
+        <option value=""></option>
+        <j:invokeStatic className="com.amazonaws.regions.Regions" method="values" var="regionsAvailable" />
+        <j:forEach items="${regionsAvailable}"  var="rgs">
+            <option value="${rgs.getName()}">${rgs.getName()}</option>
+        </j:forEach>
+      </select>
+  </f:entry>
+
   <f:entry title="Includes" field="includes">
     <f:textbox />
   </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/awsbeanstalkpublisher/extensions/AWSEBS3Setup/help-bucketRegion.html
+++ b/src/main/resources/org/jenkinsci/plugins/awsbeanstalkpublisher/extensions/AWSEBS3Setup/help-bucketRegion.html
@@ -1,0 +1,3 @@
+<div>
+    S3 Bucket Region (e.g. us-east-1)  This will be the same region set for the Elastic Beanstalk application if none is specified.
+</div>


### PR DESCRIPTION
Hi @DavidTanner,

I've been struggling with it for a while when trying to deploy my webapp app to EB using your plugin. It turns out that ```aws-beanstalk-publisher-plugin``` assumes that both S3 bucket and the EB application are within the same region. I agree that's the best practice to keep them in the same region due to the data transfer out costs. However, I've seen many cases where this rule doesn't apply.

I've made a change to this plugin to allow users to either have them within the same region or in different ones. To ensure backwards compatibility, if the user hasn't selected the ```S3 bucket region``` option, then it'll behave the same way it used to be.

This is how it's going to show up when configuring a job on Jenkins:

![screen shot 2016-07-16 at 6 31 08 pm](https://cloud.githubusercontent.com/assets/1011868/16897992/546fe4dc-4b9c-11e6-8200-aff6893a1b5f.png)

If you think this is a good addition to your plugin, please accept this PR.


Best Regards,

Paulo Almeida

This addresses the issue #32 

