### PR TITLE
The lookup should be by the name and not by the toString method

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBCredentials.java
@@ -78,7 +78,7 @@ public class AWSEBCredentials extends AbstractDescribableImpl<AWSEBCredentials> 
         Set<AWSEBCredentials> credentials = getCredentials();
 
         for (AWSEBCredentials credential : credentials) {
-            if (credential.toString().equals(credentialsString)) {
+            if (credential.getName().equals(credentialsString)) {
                 return credential;
             }
         }


### PR DESCRIPTION
We don't want to have to match to 'name + space + colon symbol + space + awsAccessKeyId' but just the name of the credential.