### PR TITLE
Fixes #48 - Added configuration option for Elastic Beanstalk version description

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBBuilderBackwardsCompatibility.java
+++ b/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBBuilderBackwardsCompatibility.java
@@ -46,7 +46,7 @@ public abstract class AWSEBBuilderBackwardsCompatibility extends Builder impleme
                 envLookup.add(byName);
                 addIfMissing(new AWSEBElasticBeanstalkSetup(awsRegion, "", credentialsName, "",
                         applicationName,
-                        versionLabelFormat, failOnError, s3Setup, envLookup));
+                        versionLabelFormat, "", failOnError, s3Setup, envLookup));
             }
 
         } catch (IOException e) {

--- a/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBPublisherBackwardsCompatibility.java
+++ b/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBPublisherBackwardsCompatibility.java
@@ -44,7 +44,7 @@ public abstract class AWSEBPublisherBackwardsCompatibility  extends Recorder {
                 envLookup.add(byName);
                 addIfMissing(new AWSEBElasticBeanstalkSetup(awsRegion, "", credentialsName, "",
                         applicationName,
-                        versionLabelFormat, failOnError, s3Setup, envLookup));
+                        versionLabelFormat, "", failOnError, s3Setup, envLookup));
             }
 
         } catch (IOException e) {

--- a/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBS3Uploader.java
+++ b/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBS3Uploader.java
@@ -35,6 +35,7 @@ public class AWSEBS3Uploader {
     
     private final String applicationName;
     private final String versionLabel;
+    private final String versionDescription;
     private final Regions awsRegion;
     private final AbstractBuild<?, ?> build;
     private final BuildListener listener;
@@ -47,13 +48,14 @@ public class AWSEBS3Uploader {
 
     public AWSEBS3Uploader(AbstractBuild<?, ?> build, BuildListener listener, Regions awsRegion,
             AWSEBCredentials credentials, AWSEBS3Setup s3Setup,
-            String applicationName, String versionLabel) {
+            String applicationName, String versionLabel, String versionDescription) {
         this.credentials = credentials;
         this.build = build;
         this.awsRegion = awsRegion;
         this.listener = listener;
         this.applicationName = AWSEBUtils.getValue(build, listener, applicationName);
         this.versionLabel = AWSEBUtils.getValue(build, listener, versionLabel);
+        this.versionDescription = AWSEBUtils.getValue(build, listener, versionDescription);
         this.keyPrefix = AWSEBUtils.getValue(build, listener, s3Setup.getKeyPrefix());
         this.bucketName = AWSEBUtils.getValue(build, listener, s3Setup.getBucketName());
         this.bucketRegion = AWSEBUtils.getValue(build, listener, s3Setup.getBucketRegion());
@@ -66,7 +68,7 @@ public class AWSEBS3Uploader {
 
 
     public AWSEBS3Uploader(AbstractBuild<?, ?> build, BuildListener listener, AWSEBElasticBeanstalkSetup envSetup, AWSEBS3Setup s3) {
-        this(build, listener, envSetup.getAwsRegion(build, listener), envSetup.getActualcredentials(build, listener), s3, envSetup.getApplicationName(), envSetup.getVersionLabelFormat());
+        this(build, listener, envSetup.getAwsRegion(build, listener), envSetup.getActualcredentials(build, listener), s3, envSetup.getApplicationName(), envSetup.getVersionLabelFormat(), envSetup.getVersionDescriptionFormat());
     }
 
 
@@ -158,8 +160,12 @@ public class AWSEBS3Uploader {
     private void createApplicationVersion(AWSElasticBeanstalk awseb) {
         AWSEBUtils.log(listener, "Creating application version %s for application %s for path %s", versionLabel, applicationName, s3ObjectPath);
 
-        CreateApplicationVersionRequest cavRequest = new CreateApplicationVersionRequest().withApplicationName(applicationName).withAutoCreateApplication(true)
-                .withSourceBundle(new S3Location(bucketName, objectKey)).withVersionLabel(versionLabel);
+        CreateApplicationVersionRequest cavRequest = new CreateApplicationVersionRequest()
+                .withApplicationName(applicationName)
+                .withAutoCreateApplication(true)
+                .withSourceBundle(new S3Location(bucketName, objectKey))
+                .withVersionLabel(versionLabel)
+                .withDescription(versionDescription);
 
         awseb.createApplicationVersion(cavRequest);
     }

--- a/src/main/resources/org/jenkinsci/plugins/awsbeanstalkpublisher/extensions/AWSEBElasticBeanstalkSetup/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsbeanstalkpublisher/extensions/AWSEBElasticBeanstalkSetup/config.jelly
@@ -38,6 +38,10 @@
   <f:entry title="Version Label Format" field="versionLabelFormat">
     <f:textbox />
   </f:entry>
+
+  <f:entry title="Version Description Format" field="versionDescriptionFormat">
+    <f:textbox />
+  </f:entry>
   
   <f:entry title="Fail if any failures" field="failOnError">
     <f:checkbox />

--- a/src/main/resources/org/jenkinsci/plugins/awsbeanstalkpublisher/extensions/AWSEBElasticBeanstalkSetup/help-versionDescriptionFormat.html
+++ b/src/main/resources/org/jenkinsci/plugins/awsbeanstalkpublisher/extensions/AWSEBElasticBeanstalkSetup/help-versionDescriptionFormat.html
@@ -1,0 +1,3 @@
+<div>
+  Sets the description of the version to be published. Jenkins environment variables are supported such as ${GIT_BRANCH} - ${BUILD_TAG}
+</div>


### PR DESCRIPTION
This PR adds functionality to allow for setting the description field of the Elastic Beanstalk CreateApplicationVersion object. This allows Jenkins job configurators to use an environment variable to set the value. As an example, I have a groovy script configured in a job that parses the git log and sets a variable to the last commit messages since the last successful build. That is then used as the description when uploaded to AWS.