### PR TITLE
Rename AWS Key

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBCredentials/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBCredentials/config.jelly
@@ -7,7 +7,7 @@
     <f:textbox/>
   </f:entry>
 
-  <f:entry title="AWS Secret Shared Key" field="awsSecretSharedKey">
+  <f:entry title="AWS Secret Access Key" field="awsSecretSharedKey">
     <f:password/>
   </f:entry>
 


### PR DESCRIPTION
Rename the AWS Key configuration to match nomenclature used by AWS.