### PR TITLE
[JENKINS-66298] Prepare AWS Elastic Beanstalk Publisher for core Guava upgrade

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBS3Uploader.java
+++ b/src/main/java/org/jenkinsci/plugins/awsbeanstalkpublisher/AWSEBS3Uploader.java
@@ -9,8 +9,6 @@ import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GetBucketAccelerateConfigurationRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Stopwatch;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
@@ -20,6 +18,7 @@ import org.jenkinsci.plugins.awsbeanstalkpublisher.extensions.AWSEBElasticBeanst
 import org.jenkinsci.plugins.awsbeanstalkpublisher.extensions.AWSEBS3Setup;
 
 import java.io.*;
+import java.util.concurrent.TimeUnit;
 
 public class AWSEBS3Uploader {
 
@@ -126,17 +125,17 @@ public class AWSEBS3Uploader {
         }
 
         if (uploadFile) {
-            final Stopwatch sw = new Stopwatch();
-            sw.start();
+            long startTimeNanos = System.nanoTime();
             s3.putObject(bucketName, objectKey, localArchive);
-            sw.stop();
-            AWSEBUtils.log(listener, "Upload took " + sw.toString());
+            long finishTimeNanos = System.nanoTime();
+            long timeElapsedMillis = TimeUnit.MILLISECONDS.convert(finishTimeNanos - startTimeNanos, TimeUnit.NANOSECONDS);
+            AWSEBUtils.log(listener, "Upload took " + timeElapsedMillis + " milliseconds");
         }
         localArchive.delete();
         createApplicationVersion(awseb);
     }
 
-    @VisibleForTesting
+    // Visible for testing
     void setS3(AmazonS3 s3) {
         this.s3 = s3;
     }


### PR DESCRIPTION
See [JENKINS-66298](https://issues.jenkins.io/browse/JENKINS-66298) and [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the `com.google.common.base.Stopwatch#toString` API, which has been removed between Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/base/Stopwatch.html) and [latest](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/base/Stopwatch.html).

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. In this PR, we migrate away from the `Stopwatch` API and use `System#nanoTime` directly. This eliminates this plugin's dependency on Guava and prepares it for the Jenkins core transition from Guava 11.0.1 to latest.

CC @DavidTanner